### PR TITLE
Fixing "walk multipart email", adding "cc" criteria, adding "get email count" keyword, updating tests

### DIFF
--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -345,7 +345,7 @@ class ImapLibrary2(object):
         | Walk Multipart Email | INDEX |
         """
         if not self._is_walking_multipart(email_index):
-            data = self._imap.uid('fetch', email_index, '(RFC822)')[1][0][1]
+            data = self._imap.uid('fetch', email_index, '(RFC822)')[1][0][1].decode('UTF-8')
             msg = message_from_string(data)
             self._start_multipart_walk(email_index, msg)
         try:
@@ -375,6 +375,7 @@ class ImapLibrary2(object):
         criteria = []
         recipient = kwargs.pop('recipient', kwargs.pop('to_email', kwargs.pop('toEmail', None)))
         sender = kwargs.pop('sender', kwargs.pop('from_email', kwargs.pop('fromEmail', None)))
+		cc = kwargs.pop('cc', kwargs.pop('cc_email', kwargs.pop('ccEmail', None)))
         status = kwargs.pop('status', None)
         subject = kwargs.pop('subject', None)
         text = kwargs.pop('text', None)
@@ -382,6 +383,8 @@ class ImapLibrary2(object):
             criteria += ['TO', '"%s"' % recipient]
         if sender:
             criteria += ['FROM', '"%s"' % sender]
+		if cc:
+            criteria += ['CC', '"%s"' % cc]
         if subject:
             criteria += ['SUBJECT', '"%s"' % subject]
         if text:

--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -356,6 +356,9 @@ class ImapLibrary2(object):
         # return number of parts
         return len(self._mp_msg.get_payload())
 
+    def get_email_count(self, **kwargs):
+        return len(self._check_emails(**kwargs))
+
     def _check_emails(self, **kwargs):
         """Returns filtered email."""
         folder = '"%s"' % str(kwargs.pop('folder', self.FOLDER))
@@ -375,7 +378,7 @@ class ImapLibrary2(object):
         criteria = []
         recipient = kwargs.pop('recipient', kwargs.pop('to_email', kwargs.pop('toEmail', None)))
         sender = kwargs.pop('sender', kwargs.pop('from_email', kwargs.pop('fromEmail', None)))
-		cc = kwargs.pop('cc', kwargs.pop('cc_email', kwargs.pop('ccEmail', None)))
+        cc = kwargs.pop('cc', kwargs.pop('cc_email', kwargs.pop('ccEmail', None)))
         status = kwargs.pop('status', None)
         subject = kwargs.pop('subject', None)
         text = kwargs.pop('text', None)
@@ -383,7 +386,7 @@ class ImapLibrary2(object):
             criteria += ['TO', '"%s"' % recipient]
         if sender:
             criteria += ['FROM', '"%s"' % sender]
-		if cc:
+        if cc:
             criteria += ['CC', '"%s"' % cc]
         if subject:
             criteria += ['SUBJECT', '"%s"' % subject]
@@ -415,5 +418,3 @@ class ImapLibrary2(object):
         """Saves all existing emails to internal variable."""
         typ, mails = self._imap.uid('search', None, 'ALL')
         self._mails = mails[0].split()
-
-

--- a/test/utest/test_imaplibrary.py
+++ b/test/utest/test_imaplibrary.py
@@ -21,17 +21,17 @@ IMAP Library - a IMAP email testing library.
 
 from sys import path
 path.append('src')
-from ImapLibrary import ImapLibrary
+from ImapLibrary2 import ImapLibrary2
 import mock
 import unittest
 
 
-class ImapLibraryTests(unittest.TestCase):
+class ImapLibrary2Tests(unittest.TestCase):
     """Imap library test class."""
 
     def setUp(self):
         """Instantiate the Imap library class."""
-        self.library = ImapLibrary()
+        self.library = ImapLibrary2()
         self.password = 'password'
         self.port = 143
         self.port_secure = 993
@@ -48,7 +48,7 @@ class ImapLibraryTests(unittest.TestCase):
 
     def test_should_have_default_values(self):
         """Imap library instance should have default values set."""
-        self.assertIsInstance(self.library, ImapLibrary)
+        self.assertIsInstance(self.library, ImapLibrary2)
         self.assertIsNone(self.library._email_index)
         self.assertIsNone(self.library._imap)
         self.assertIsInstance(self.library._mails, list)
@@ -59,7 +59,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.assertEqual(self.library.PORT_SECURE, self.port_secure)
         self.assertEqual(self.library.FOLDER, self.folder)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_open_secure_mailbox(self, mock_imap):
         """Open mailbox should open secure connection to IMAP server
         with requested credentials.
@@ -70,7 +70,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.login.assert_called_with(self.username, self.password)
         self.library._imap.select.assert_called_with(self.folder_check)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_open_secure_mailbox_with_custom_port(self, mock_imap):
         """Open mailbox should open secure connection to IMAP server
         with requested credentials and custom port.
@@ -81,7 +81,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.login.assert_called_with(self.username, self.password)
         self.library._imap.select.assert_called_with(self.folder_check)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_open_secure_mailbox_with_custom_folder(self, mock_imap):
         """Open mailbox should open secure connection to IMAP server with
         requested credentials to a custom folder
@@ -92,7 +92,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.login.assert_called_with(self.username, self.password)
         self.library._imap.select.assert_called_with('"Outbox"')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_open_secure_mailbox_with_server_key(self, mock_imap):
         """Open mailbox should open secure connection to IMAP server
         using 'server' key with requested credentials.
@@ -103,7 +103,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.login.assert_called_with(self.username, self.password)
         self.library._imap.select.assert_called_with(self.folder_check)
 
-    @mock.patch('ImapLibrary.IMAP4')
+    @mock.patch('ImapLibrary2.IMAP4')
     def test_should_open_non_secure_mailbox(self, mock_imap):
         """Open mailbox should open non-secure connection to IMAP server
         with requested credentials.
@@ -114,7 +114,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.login.assert_called_with(self.username, self.password)
         self.library._imap.select.assert_called_with(self.folder_check)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index(self, mock_imap):
         """Returns email index from connected IMAP session."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -127,7 +127,7 @@ class ImapLibraryTests(unittest.TestCase):
                                                     '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_with_sender_filter(self, mock_imap):
         """Returns email index from connected IMAP session
         with sender filter.
@@ -152,7 +152,7 @@ class ImapLibraryTests(unittest.TestCase):
                                                     '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_with_recipient_filter(self, mock_imap):
         """Returns email index from connected IMAP session
         with recipient filter.
@@ -175,9 +175,9 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.uid.assert_called_with('search', None, 'TO',
                                                      '"%s"' % self.recipient)
-        self.assertEqual(index, '0')      
+        self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_with_subject_filter(self, mock_imap):
         """Returns email index from connected IMAP session
         with subject filter.
@@ -192,7 +192,7 @@ class ImapLibraryTests(unittest.TestCase):
                                                      '"%s"' % self.subject)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_with_text_filter(self, mock_imap):
         """Returns email index from connected IMAP session with text filter."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -205,7 +205,7 @@ class ImapLibraryTests(unittest.TestCase):
                                                      '"%s"' % self.text)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_with_status_filter(self, mock_imap):
         """Returns email index from connected IMAP session with status filter."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -217,7 +217,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.uid.assert_called_with('search', None, self.status)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_with_folder_filter(self, mock_imap):
         """Returns email index from connected IMAP session with
         folder filter.
@@ -232,7 +232,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.assert_called_with(self.folder_filter)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_without_filter(self, mock_imap):
         """Returns email index from connected IMAP session without filter."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -244,23 +244,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.uid.assert_called_with('search', None, self.status)
         self.assertEqual(index, '0')
 
-    # DEPRECATED
-    @mock.patch('ImapLibrary.IMAP4_SSL')
-    def test_should_return_email_index_from_deprecated_keyword(self, mock_imap):
-        """Returns email index from connected IMAP session
-        using deprecated keyword.
-        """
-        self.library.open_mailbox(host=self.server, user=self.username,
-                                  password=self.password)
-        self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.uid.return_value = ['OK', ['0']]
-        index = self.library.wait_for_mail(sender=self.sender)
-        self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.uid.assert_called_with('search', None, 'FROM',
-                                                     '"%s"' % self.sender)
-        self.assertEqual(index, '0')
-
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_return_email_index_after_delay(self, mock_imap):
         """Returns email index from connected IMAP session after some delay."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -273,7 +257,7 @@ class ImapLibraryTests(unittest.TestCase):
                                                      '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_raise_exception_on_timeout(self, mock_imap):
         """Raise exception on timeout."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -286,7 +270,7 @@ class ImapLibraryTests(unittest.TestCase):
             self.assertTrue("No email received within 0s" in context.exception)
         self.library._imap.select.assert_called_with(self.folder_check)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_raise_exception_on_select_error(self, mock_imap):
         """Raise exception on imap select error."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -297,7 +281,7 @@ class ImapLibraryTests(unittest.TestCase):
             self.assertTrue("imap.select error: NOK, ['1']" in context.exception)
         self.library._imap.select.assert_called_with(self.folder_check)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_raise_exception_on_search_error(self, mock_imap):
         """Raise exception on imap search error."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -312,17 +296,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.uid.assert_called_with('search', None, 'FROM', '"%s"' %
                                                      self.sender)
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
-    def test_should_delete_all_emails(self, mock_imap):
-        """Delete all emails."""
-        self.library.open_mailbox(host=self.server, user=self.username,
-                                  password=self.password)
-        self.library._mails = ['0']
-        self.library.delete_all_emails()
-        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'(\DELETED)')
-        self.library._imap.expunge.assert_called_with()
-
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_delete_email(self, mock_imap):
         """Delete specific email."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -331,26 +305,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'(\DELETED)')
         self.library._imap.expunge.assert_called_with()
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
-    def test_should_mark_all_emails_as_read(self, mock_imap):
-        """Mark all emails as read."""
-        self.library.open_mailbox(host=self.server, user=self.username,
-                                  password=self.password)
-        self.library._mails = ['0']
-        self.library.mark_all_emails_as_read()
-        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'\SEEN')
-
-    # DEPRECATED
-    @mock.patch('ImapLibrary.IMAP4_SSL')
-    def test_should_mark_all_emails_as_read_from_deprecated_keyword(self, mock_imap):
-        """Mark all emails as read using deprecated keyword."""
-        self.library.open_mailbox(host=self.server, user=self.username,
-                                  password=self.password)
-        self.library._mails = ['0']
-        self.library.mark_as_read()
-        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'\SEEN')
-
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_mark_email_as_read(self, mock_imap):
         """Mark specific email as read."""
         self.library.open_mailbox(host=self.server, user=self.username,
@@ -358,7 +313,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.mark_email_as_read('0')
         self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'\SEEN')
 
-    @mock.patch('ImapLibrary.IMAP4_SSL')
+    @mock.patch('ImapLibrary2.IMAP4_SSL')
     def test_should_close_mailbox(self, mock_imap):
         """Close opened connection."""
         self.library.open_mailbox(host=self.server, user=self.username,


### PR DESCRIPTION
Without decoding the data sent to "message_from_string()" function under the walk_multipart_email keyword will results in the following error:
 - TypeError: initial_value must be str or None, not bytes

Added .decode('utf-8') to fix it.

Added "get email count" keyword for asserting that the email folder contains X amount of emails that fulfill the set criteria. Added "cc" criteria to filter emails.

Updated library name in tests and removed deprecated tests.
Also removed "test_should_mark_all_emails_as_read" and "test_should_delete_all_emails" as they wont work with "self._get_all_emails()" being called inside the keyword.