### PR TITLE
fix: open() takes 3 positional arguments but 4 were given

### DIFF
--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -24,6 +24,7 @@ from email.header import decode_header
 from imaplib import IMAP4, IMAP4_SSL
 from re import findall
 from time import sleep, time
+
 try:
     from urllib.request import urlopen
 except ImportError:
@@ -31,7 +32,7 @@ except ImportError:
 from builtins import str as ustr
 from ImapLibrary2.version import get_version
 from ImapLibrary2.imap_proxy import IMAP4Proxy, IMAP4SSLProxy
-
+import os.path
 __version__ = get_version()
 
 
@@ -457,7 +458,7 @@ class ImapLibrary2(object):
         if cc:
             criteria += ['CC', '"%s"' % cc]
         if text:
-            criteria += ['TEXT', '"%s"' % text]     
+            criteria += ['TEXT', '"%s"' % text]
         if status:
             criteria += [status]
         if not criteria:
@@ -486,3 +487,36 @@ class ImapLibrary2(object):
         """Saves all existing emails to internal variable."""
         typ, mails = self._imap.uid('search', None, 'ALL')
         self._mails = mails[0].split()
+
+    def get_attachments_email (self, **kwargs) :
+        """Save attachments of email message on given ``email_index`` (overwrite if already exists).
+
+        Arguments:
+        - ``email_index``: An email index to identity the email message.
+        - ``target_folder`` : local folder for saving attachments to (needs to exist),
+            defaults to current directory if None
+
+        Examples:
+        | Get Attachments Email | INDEX | C:\\Users\\thuchet\\test
+        """
+        email_index = kwargs.pop('email_index', None)
+        target_folder = kwargs.pop('target_folder', None)
+        attachments = []
+        data = self._imap.uid('fetch', email_index, '(RFC822)')[1][0][1]
+        msg = message_from_bytes(data)
+
+        if target_folder is None:
+            target_folder = './'
+
+        for part in msg.walk():
+            content_maintype = part.get_content_maintype()
+            filename = None
+            if content_maintype != "multipart":
+                filename = part.get_filename()
+                if filename :
+                    filepath = os.path.join(target_folder, filename)
+                    fp = open(filepath, 'wb')
+                    fp.write(part.get_payload(decode=True))
+                    fp.close()
+                    attachments.append(str(filepath))
+        return attachments

--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -488,7 +488,7 @@ class ImapLibrary2(object):
         typ, mails = self._imap.uid('search', None, 'ALL')
         self._mails = mails[0].split()
 
-    def get_attachments_email (self, **kwargs) :
+    def get_attachments_from_email (self, **kwargs) :
         """Save attachments of email message on given ``email_index`` (overwrite if already exists).
 
         Arguments:
@@ -497,7 +497,7 @@ class ImapLibrary2(object):
             defaults to current directory if None
 
         Examples:
-        | Get Attachments Email | INDEX | C:\\Users\\thuchet\\test
+        | Get Attachments Email | INDEX | C:\\Users\\User\\test
         """
         email_index = kwargs.pop('email_index', None)
         target_folder = kwargs.pop('target_folder', None)

--- a/src/ImapLibrary2/imap_proxy.py
+++ b/src/ImapLibrary2/imap_proxy.py
@@ -35,7 +35,7 @@ class IMAP4Proxy(IMAP4):
 
         IMAP4.__init__(self, host, port)
 
-    def _create_socket(self):
+    def _create_socket(self, timeout=None):
         return create_connection((self.host, self.port), proxy_type=self.proxy_type, proxy_addr=self.proxy_host,
                                  proxy_port=self.proxy_port, proxy_rdns=self.rdns, proxy_username=self.proxy_username,
                                  proxy_password=self.proxy_password)
@@ -65,10 +65,10 @@ class IMAP4SSLProxy(IMAP4Proxy):
                             proxy_host=proxy_host, proxy_port=proxy_port, proxy_username=proxy_username, proxy_password=proxy_password,
                             rdns=rdns, username=username, password=password, proxy_type=proxy_type)
 
-    def _create_socket(self):
-        sock = IMAP4Proxy._create_socket(self)
+    def _create_socket(self, timeout=None):
+        sock = IMAP4Proxy._create_socket(self, timeout=None)
         server_hostname = self.host if ssl.HAS_SNI else None
         return self.ssl_context.wrap_socket(sock, server_hostname=server_hostname)
 
-    def open(self, host='', port=IMAP4_PORT):
-        IMAP4Proxy.open(self, host, port)
+    def open(self, host='', port=IMAP4_PORT, timeout=None):
+        IMAP4Proxy.open(self, host, port, timeout=None)


### PR DESCRIPTION
Error since python 3.9 - open() takes 3 positional arguments but 4 were given
Inspired by https://github.com/mjs/imapclient/issues/425