### PR TITLE
Improvement of the  `_check_emails` method to handle Non-ASCII characters in email summary

### DIFF
--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -422,16 +422,18 @@ class ImapLibrary2(object):
 
     def _check_emails(self, **kwargs):
         """Returns filtered email."""
-        folder = '"%s"' % str(kwargs.pop('folder', self.FOLDER))
-        criteria = self._criteria(**kwargs)
+        search_cmd = ["search", None]
+        search_cmd += self._criteria(**kwargs)
         # Calling select before each search is necessary with gmail
+        folder = '"%s"' % str(kwargs.pop('folder', self.FOLDER))
         status, data = self._imap.select(folder)
         if status != 'OK':
             raise Exception("imap.select error: %s, %s" % (status, data))
         subject = kwargs.pop('subject', None)
         if subject:
             self._imap.literal = subject.encode("utf-8")
-        typ, msgnums = self._imap.uid('search', None, *criteria)
+            search_cmd = search_cmd[:1] + ['CHARSET', 'UTF-8'] + search_cmd[2:]
+        typ, msgnums = self._imap.uid(*search_cmd)
         if typ != 'OK':
             raise Exception('imap.search error: %s, %s, criteria=%s' % (typ, msgnums, criteria))
         if msgnums[0] is not None:

--- a/src/ImapLibrary2/version.py
+++ b/src/ImapLibrary2/version.py
@@ -19,7 +19,7 @@
 IMAP Library - a IMAP email testing library.
 """
 
-VERSION = '0.4.6'
+VERSION = '0.4.7'
 
 
 def get_version():


### PR DESCRIPTION
Fix for Issue: [Issue #24](https://github.com/lasselindqvist/robotframework-imaplibrary2/issues/24)

Problem Statement:
The problem of handling non-ASCII characters in email summaries is still relevant. Specifically, the 'CHARSET', 'UTF-8' modification needs to be applied to the UID command to properly read UTF-8 encoded summaries otherwise the `Could not parse command` error will be raised

Solution:
The solution involves modifying the command construction process. The approach to building the command array has been adjusted to include the UTF-8 charset when the subject criteria are specified. This ensures that the UID command can process UTF-8 encoded summaries correctly. There are no other changes apart from this specific adjustment.

Additional Notes:
I am uncertain if the version number needs to be incremented for this change. Please advise if a rollback is necessary regarding versioning.