### PR TITLE
add `get_multipart_param(param)`

### DIFF
--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -184,6 +184,14 @@ class ImapLibrary2(object):
         """
         return self._part.get_content_type()
 
+    def get_multipart_param(self, param:str):
+        """Returns the content type parameter ``param`` of current part of selected multipart email message.
+
+        Examples:
+        | Get Multipart Param |
+        """
+        return self._part.get_param(param)
+
     def get_multipart_field(self, field):
         """Returns the value of given header ``field`` name.
 

--- a/src/ImapLibrary2/__init__.py
+++ b/src/ImapLibrary2/__init__.py
@@ -184,13 +184,19 @@ class ImapLibrary2(object):
         """
         return self._part.get_content_type()
 
-    def get_multipart_param(self, param:str):
-        """Returns the content type parameter ``param`` of current part of selected multipart email message.
+    def get_multipart_param(self, param:str, header='content-type'):
+        """Return the value of the ``Content-Type`` header’s parameter ``param`` as a string.
+        If the message has no ``Content-Type`` header or if there is no such parameter, then
+        ``None`` is returned.
+
+        Optional ``header`` if given, specifies the message header to use instead of ``Content-Type``
 
         Examples:
-        | Get Multipart Param |
+        | Get Multipart Param | charset   |                            |
+        | Get Multipart Param | name      | header=Content-Type        |
+        | Get Multipart Param | filename  | header=Content-Disposition |
         """
-        return self._part.get_param(param)
+        return self._part.get_param(param, header=header)
 
     def get_multipart_field(self, field):
         """Returns the value of given header ``field`` name.


### PR DESCRIPTION
`get_multipart_param` would be useful to check charset of email body and filename of attachemnt.

i.e.:
```
...
   # message body
   
    ${charset}=  Get Multipart Param  charset
    Should Be Equal As Strings  ${charset}  us-ascii
...
   # message attachment

    ${name}=  Get Multipart Param  name
    Should Be Equal As Strings   ${name}   test.zip
...
```